### PR TITLE
chore: set up dependabot, bump GHA deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+    reviewers:
+      - kanadgupta
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    reviewers:
+      - kanadgupta
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [14, 16, 18]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm install and test
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Sync using current glitch-sync code
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,11 +24,10 @@ jobs:
   # Testing the `path` parameter
   # Glitch Project: https://glitch.com/edit/#!/github-action-sandbox
   # Resulting output: https://github-action-sandbox.glitch.me/
-  e2e-path-test:
+  sync-with-path:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - name: Sync using current glitch-sync code
         uses: ./
         with:


### PR DESCRIPTION
Noticed the following warnings in [the latest CI run](https://github.com/kanadgupta/glitch-sync/actions/runs/3473469075) (GitHub should really do a better job of surfacing these annotations):

<img width="925" alt="Screen Shot 2022-11-23 at 10 17 27 AM" src="https://user-images.githubusercontent.com/8854718/203596168-b3f572bc-0245-419f-83a8-a31b5a228adb.png">
