### PR TITLE
refactor: remove `@actions/core`

### DIFF
--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -78,7 +78,7 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain('::error::Error running workflow: Input required and not supplied: project-id');
+    expect(output).toMatch(/\n::error::Error running workflow: Input required and not supplied: project-id\n/);
   });
 
   it('should fail if missing auth param', async () => {
@@ -87,7 +87,7 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain('::error::Error running workflow: Input required and not supplied: auth-token');
+    expect(output).toMatch(/\n::error::Error running workflow: Input required and not supplied: auth-token\n/);
   });
 
   it('should fail if github env variables are missing', async () => {
@@ -98,8 +98,8 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain(
-      '::error::Error running workflow: Unable to detect critical GitHub Actions environment variables. Are you running this in a GitHub Action?',
+    expect(output).toMatch(
+      /\n::error::Error running workflow: Unable to detect critical GitHub Actions environment variables. Are you running this in a GitHub Action\?\n/,
     );
   });
 
@@ -117,7 +117,7 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain('::error::Error syncing to Glitch: Forbidden');
+    expect(output).toMatch(/\n::error::Error syncing to Glitch: Forbidden\n/);
   });
 
   it('should fail and display status text if Glitch API responds with non-JSON response', async () => {
@@ -135,8 +135,8 @@ describe('glitch-sync main runner tests', () => {
 
     const output = getCommandOutput();
 
-    expect(output).toContain('::debug::Raw 403 error response from Glitch: <html></html>');
-    expect(output).toContain('::error::Error syncing to Glitch: Forbidden');
+    expect(output).toMatch(/\n::debug::Raw 403 error response from Glitch: <html><\/html>\n/);
+    expect(output).toMatch(/\n::error::Error syncing to Glitch: Forbidden\n/);
   });
 
   it('should fail and display status text if Glitch API responds with non-JSON response and custom status text', async () => {
@@ -154,8 +154,8 @@ describe('glitch-sync main runner tests', () => {
 
     const output = getCommandOutput();
 
-    expect(output).toContain('::debug::Raw 403 error response from Glitch: <html></html>');
-    expect(output).toContain('::error::Error syncing to Glitch: custom status text');
+    expect(output).toMatch(/\n::debug::Raw 403 error response from Glitch: <html><\/html>\n/);
+    expect(output).toMatch(/\n::error::Error syncing to Glitch: custom status text\n/);
   });
 
   it('should fail if Glitch API fails with JSON response body', async () => {
@@ -185,8 +185,8 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain(
-      "::error::Error syncing to Glitch: mv: cannot stat '/tmp/tmp.pDQPiXJ6CU/non-existent-path/*': No such file or directory",
+    expect(output).toMatch(
+      /\n::error::Error syncing to Glitch: mv: cannot stat '\/tmp\/tmp.pDQPiXJ6CU\/non-existent-path\/\*': No such file or directory%0A\n/,
     );
   });
 
@@ -197,7 +197,7 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain('Glitch project successfully updated! 🎉');
+    expect(output).toMatch(/\nGlitch project successfully updated! 🎉\n/);
   });
 
   it('should run with optional path param', async () => {
@@ -215,7 +215,7 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain('Glitch project successfully updated! 🎉');
+    expect(output).toMatch(/\nGlitch project successfully updated! 🎉\n/);
   });
 
   it('should run with optional repo param', async () => {
@@ -234,6 +234,6 @@ describe('glitch-sync main runner tests', () => {
     await expect(run()).resolves.toBeUndefined();
 
     const output = getCommandOutput();
-    expect(output).toContain('Glitch project successfully updated! 🎉');
+    expect(output).toMatch(/\nGlitch project successfully updated! 🎉\n/);
   });
 });

--- a/core.ts
+++ b/core.ts
@@ -44,7 +44,7 @@ function issueCommand(command: 'debug' | 'error', message: unknown): void {
  * Writes debug message to user log
  * @param message debug message
  */
-export function debug(message: unknown) {
+export function debug(message: string): void {
   issueCommand('debug', message);
 }
 
@@ -54,7 +54,7 @@ export function debug(message: unknown) {
  *
  * @param name name of the input to get
  */
-export function getInput(name: string, options: { required?: boolean } = {}) {
+export function getInput(name: string, options: { required?: boolean } = {}): string {
   const val: string = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
   if (options.required && !val) {
     throw new Error(`Input required and not supplied: ${name}`);

--- a/core.ts
+++ b/core.ts
@@ -1,0 +1,82 @@
+import os from 'node:os';
+
+/**
+ * This file is a lightweight re-implementation of the functions
+ * in `@actions/core`.
+ *
+ * @see {@link https://github.com/actions/toolkit/tree/main/packages/core}
+ * @see {@link https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions}
+ */
+
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input: unknown): string {
+  if (input === null || input === undefined) {
+    return '';
+  } else if (typeof input === 'string' || input instanceof String) {
+    return input as string;
+  }
+  return JSON.stringify(input);
+}
+
+function escapeData(s: unknown): string {
+  return toCommandValue(s).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+/**
+ * Commands
+ *
+ * Command Format:
+ *   ::name key=value,key=value::message
+ *
+ * Examples:
+ *   ::debug::This is the debug message
+ *   ::error::This is the error message
+ */
+function issueCommand(command: 'debug' | 'error', message: unknown): void {
+  const cmd = `::${command}::${escapeData(message)}`;
+  process.stdout.write(cmd.toString() + os.EOL);
+}
+
+/**
+ * Writes debug message to user log
+ * @param message debug message
+ */
+export function debug(message: unknown) {
+  issueCommand('debug', message);
+}
+
+/**
+ * Gets the value of an input.
+ * Returns an empty string if the value is not defined.
+ *
+ * @param name name of the input to get
+ */
+export function getInput(name: string, options: { required?: boolean } = {}) {
+  const val: string = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+  if (options.required && !val) {
+    throw new Error(`Input required and not supplied: ${name}`);
+  }
+  return val.trim();
+}
+
+/**
+ * Writes info to log with console.log.
+ * @param message info message
+ */
+export function info(message: string): void {
+  process.stdout.write(message + os.EOL);
+}
+
+/**
+ * Sets the action status to failed.
+ * When the action exits it will be with an exit code of 1
+ * @param message add error issue message
+ */
+export function setFailed(message: string | Error): void {
+  process.exitCode = 1;
+
+  issueCommand('error', message instanceof Error ? message.toString() : message);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "glitch-sync",
       "version": "3.0.0",
       "license": "ISC",
-      "dependencies": {
-        "@actions/core": "^1.10.1"
-      },
       "devDependencies": {
         "@readme/eslint-config": "^13.0.1",
         "@vercel/ncc": "^0.38.0",
@@ -32,24 +29,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@actions/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
-      "dependencies": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@actions/http-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
-      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
-      "dependencies": {
-        "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -667,14 +646,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -6891,14 +6862,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7031,17 +6994,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "5.25.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
-      "integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -7078,14 +7030,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "keywords": [],
   "author": "Kanad Gupta",
   "license": "ISC",
-  "dependencies": {
-    "@actions/core": "^1.10.1"
-  },
   "devDependencies": {
     "@readme/eslint-config": "^13.0.1",
     "@vercel/ncc": "^0.38.0",

--- a/run.ts
+++ b/run.ts
@@ -1,4 +1,4 @@
-import * as core from '@actions/core';
+import * as core from './core.js';
 
 export default async function run() {
   try {


### PR DESCRIPTION
`@actions/core` is getting increasingly heavy, so this PR tightens up our test coverage and backfills some of functions that we use in `@actions/core`.